### PR TITLE
Rename `base_asset` to `market_token`

### DIFF
--- a/contracts/lendex-credit-agency/src/msg.rs
+++ b/contracts/lendex-credit-agency/src/msg.rs
@@ -31,7 +31,7 @@ pub struct MarketConfig {
     /// Decimals for sub-tokens `L` and `B`
     pub decimals: u8,
     /// Native denom for the base asset
-    pub base_asset: String,
+    pub market_token: String,
     /// Interest rate curve
     pub interest_rate: Interest,
     /// Define interest's charged period (in seconds)
@@ -44,7 +44,7 @@ pub enum QueryMsg {
     /// Returns current configuration
     Configuration {},
     /// Queries a market address by base asset
-    Market { base_asset: String },
+    Market { market_token: String },
     /// List all base assets and the addresses of markets handling them.
     /// Pagination by base asset
     ListMarkets {
@@ -55,7 +55,7 @@ pub enum QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct MarketResponse {
-    pub base_asset: String,
+    pub market_token: String,
     pub market: Addr,
 }
 

--- a/contracts/lendex-credit-agency/src/multitest/queries.rs
+++ b/contracts/lendex-credit-agency/src/multitest/queries.rs
@@ -6,7 +6,7 @@ fn query_market() {
 
     suite.create_market_quick("gov", "osmo", "OSMO").unwrap();
     let res = suite.query_market("OSMO").unwrap();
-    assert_eq!(res.base_asset, "OSMO");
+    assert_eq!(res.market_token, "OSMO");
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn list_markets() {
         .unwrap()
         .markets
         .into_iter()
-        .map(|r| r.base_asset)
+        .map(|r| r.market_token)
         .collect();
     list.sort();
 
@@ -70,7 +70,7 @@ fn list_markets_default_pagination() {
         .unwrap()
         .markets
         .into_iter()
-        .map(|r| r.base_asset)
+        .map(|r| r.market_token)
         .collect();
     list1.sort();
     assert_eq!(list1, generate_denoms("TOKEN", 0, 10));
@@ -80,7 +80,7 @@ fn list_markets_default_pagination() {
         .unwrap()
         .markets
         .into_iter()
-        .map(|r| r.base_asset)
+        .map(|r| r.market_token)
         .collect();
     list2.sort();
     assert_eq!(list2, generate_denoms("TOKEN", 10, 15));
@@ -103,7 +103,7 @@ fn list_markets_custom_pagination() {
         .unwrap()
         .markets
         .into_iter()
-        .map(|r| r.base_asset)
+        .map(|r| r.market_token)
         .collect();
     list1.sort();
     assert_eq!(list1, generate_denoms("TOKEN", 0, 3));
@@ -113,7 +113,7 @@ fn list_markets_custom_pagination() {
         .unwrap()
         .markets
         .into_iter()
-        .map(|r| r.base_asset)
+        .map(|r| r.market_token)
         .collect();
     list2.sort();
     assert_eq!(list2, generate_denoms("TOKEN", 3, 5));

--- a/contracts/lendex-credit-agency/src/multitest/suite.rs
+++ b/contracts/lendex-credit-agency/src/multitest/suite.rs
@@ -116,7 +116,7 @@ impl Suite {
         &mut self,
         caller: &str,
         lendex_token: &str,
-        base_asset: &str,
+        market_token: &str,
     ) -> AnyResult<AppResponse> {
         self.create_market(
             caller,
@@ -124,7 +124,7 @@ impl Suite {
                 name: lendex_token.to_string(),
                 symbol: lendex_token.to_string(),
                 decimals: 9,
-                base_asset: base_asset.to_string(),
+                market_token: market_token.to_string(),
                 interest_rate: Interest::Linear {
                     base: Decimal::percent(3),
                     slope: Decimal::percent(20),
@@ -148,7 +148,7 @@ impl Suite {
         let resp: MarketResponse = self.app.wrap().query_wasm_smart(
             self.contract.clone(),
             &QueryMsg::Market {
-                base_asset: asset.to_string(),
+                market_token: asset.to_string(),
             },
         )?;
         Ok(resp)
@@ -156,7 +156,7 @@ impl Suite {
 
     pub fn assert_market(&self, asset: &str) {
         let res = self.query_market(asset).unwrap();
-        assert_eq!(res.base_asset, asset);
+        assert_eq!(res.market_token, asset);
 
         // We query the supposed market contract address to make extra sure
         // it was instantiated properly and exists.
@@ -165,7 +165,7 @@ impl Suite {
             .wrap()
             .query_wasm_smart(res.market, &lendex_market::msg::QueryMsg::Configuration {})
             .unwrap();
-        assert_eq!(resp.base_asset, asset);
+        assert_eq!(resp.market_token, asset);
     }
 
     /// Queries the Credit Agency contract for a list of markets with pagination

--- a/contracts/lendex-credit-agency/src/state.rs
+++ b/contracts/lendex-credit-agency/src/state.rs
@@ -33,7 +33,7 @@ impl MarketState {
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
-/// A map of reply_id -> base_asset, used to tell which base asset
+/// A map of reply_id -> market_token, used to tell which base asset
 /// a given instantiating contract will handle
 pub const REPLY_IDS: Map<u64, String> = Map::new("reply_ids");
 /// The next unused reply ID

--- a/contracts/lendex-market/README.md
+++ b/contracts/lendex-market/README.md
@@ -11,13 +11,16 @@ pub struct InstantiateMsg {
     pub symbol: String,
     pub decimals: u8,
     pub token_id: u64,
-    pub base_asset: String,
+    pub market_token: String,
+    pub interest_rate: Interest,
+    pub distributed_token: String,
+    pub interest_charge_period: u64,
 }
 ```
 
 ## Messages
 
-`Deposit {}` - deposits funds. If denom matches `base_asset`, proper amount of tokens will be minted and sent to ltoken account
+`Deposit {}` - deposits funds. If denom matches `market_token`, proper amount of tokens will be minted and sent to ltoken account
 
 `Withdraw { amount: Uint128 }` - requests to withdraw the amount of ltokens
 

--- a/contracts/lendex-market/src/msg.rs
+++ b/contracts/lendex-market/src/msg.rs
@@ -14,8 +14,8 @@ pub struct InstantiateMsg {
     pub decimals: u8,
     /// CodeId used to create sub-tokens `L` and `B`
     pub token_id: u64,
-    /// Native denom for the base asset
-    pub base_asset: String,
+    /// Native denom for the market tokene
+    pub market_token: String,
     /// Interest rate curve
     pub interest_rate: Interest,
     /// Token which would be distributed via created lendex contracts
@@ -27,13 +27,13 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    /// X base_asset must be sent along with this message. If it matches, X l_token is minted of the sender address.
-    /// The underlying base_asset is stored in this Market contract
+    /// X market_token must be sent along with this message. If it matches, X l_token is minted of the sender address.
+    /// The underlying market_token is stored in this Market contract
     Deposit {},
     /// This requests to withdraw the amount of L Tokens. More specifically,
     /// the contract will burn amount L Tokens and return that to the lender in base asset.
     Withdraw { amount: Uint128 },
-    /// If sent tokens' denom matches base_asset, burns tokens from sender's address
+    /// If sent tokens' denom matches market_token, burns tokens from sender's address
     Repay {},
     /// Dispatches two messages, one to mint amount of BToken for this sender,
     /// and the other to send amount base asset to the sender

--- a/contracts/lendex-market/src/multitest/borrow_repay.rs
+++ b/contracts/lendex-market/src/multitest/borrow_repay.rs
@@ -7,7 +7,7 @@ fn borrow_works() {
     let borrower = "borrower";
     let mut suite = SuiteBuilder::new()
         .with_contract_funds(coin(150, "ATOM"))
-        .with_base_asset("ATOM")
+        .with_market_token("ATOM")
         .build();
 
     // At first, the borrower has no b-token, and the contract has some base assets
@@ -24,10 +24,10 @@ fn borrow_works() {
 #[test]
 fn borrow_and_repay() {
     let borrower = "borrower";
-    let base_asset = "ATOM";
+    let market_token = "ATOM";
     let mut suite = SuiteBuilder::new()
-        .with_contract_funds(coin(150, base_asset))
-        .with_base_asset(base_asset)
+        .with_contract_funds(coin(150, market_token))
+        .with_market_token(market_token)
         .build();
 
     // Borrow some tokens
@@ -35,7 +35,7 @@ fn borrow_and_repay() {
     assert_eq!(suite.query_contract_asset_balance().unwrap(), 50);
 
     // Repay all borrowed tokens
-    suite.repay(borrower, coin(100, base_asset)).unwrap();
+    suite.repay(borrower, coin(100, market_token)).unwrap();
     assert_eq!(suite.query_contract_asset_balance().unwrap(), 150);
     assert_eq!(suite.query_btoken_balance(borrower).unwrap().u128(), 0);
 }
@@ -43,21 +43,21 @@ fn borrow_and_repay() {
 #[test]
 fn repay_small_amounts() {
     let borrower = "borrower";
-    let base_asset = "ATOM";
+    let market_token = "ATOM";
     let mut suite = SuiteBuilder::new()
-        .with_contract_funds(coin(100, base_asset))
-        .with_base_asset(base_asset)
+        .with_contract_funds(coin(100, market_token))
+        .with_market_token(market_token)
         .build();
 
     // Borrow some tokens
     suite.borrow(borrower, 100).unwrap();
 
     // Repay some borrowed tokens
-    suite.repay(borrower, coin(33, base_asset)).unwrap();
+    suite.repay(borrower, coin(33, market_token)).unwrap();
     assert_eq!(suite.query_contract_asset_balance().unwrap(), 33);
     assert_eq!(suite.query_btoken_balance(borrower).unwrap().u128(), 67);
 
-    suite.repay(borrower, coin(67, base_asset)).unwrap();
+    suite.repay(borrower, coin(67, market_token)).unwrap();
     assert_eq!(suite.query_contract_asset_balance().unwrap(), 100);
     assert_eq!(suite.query_btoken_balance(borrower).unwrap().u128(), 0);
 }
@@ -65,18 +65,18 @@ fn repay_small_amounts() {
 #[test]
 fn overpay_repay() {
     let borrower = "borrower";
-    let base_asset = "ATOM";
+    let market_token = "ATOM";
     let mut suite = SuiteBuilder::new()
-        .with_funds(borrower, &[coin(50, base_asset)])
-        .with_contract_funds(coin(100, base_asset))
-        .with_base_asset(base_asset)
+        .with_funds(borrower, &[coin(50, market_token)])
+        .with_contract_funds(coin(100, market_token))
+        .with_market_token(market_token)
         .build();
 
     // Borrow some tokens
     suite.borrow(borrower, 100).unwrap();
 
     // Overpay borrowed tokens - 120 instead of 100
-    suite.repay(borrower, coin(120, base_asset)).unwrap();
+    suite.repay(borrower, coin(120, market_token)).unwrap();
     // Contract will still have only initial 100 tokens, since it sends
     // surplus back to borrower
     assert_eq!(suite.query_contract_asset_balance().unwrap(), 100);

--- a/contracts/lendex-market/src/multitest/deposit.rs
+++ b/contracts/lendex-market/src/multitest/deposit.rs
@@ -7,7 +7,7 @@ fn deposit_works() {
     let lender = "lender";
     let mut suite = SuiteBuilder::new()
         .with_funds(lender, &[coin(100, "ATOM")])
-        .with_base_asset("ATOM")
+        .with_market_token("ATOM")
         .build();
 
     // At first, the lender has no l-token, and the contract has no base asset.
@@ -26,7 +26,7 @@ fn deposit_multiple_denoms_fails() {
     let lender = "lender";
     let mut suite = SuiteBuilder::new()
         .with_funds(lender, &[coin(100, "ATOM"), coin(50, "BTC")])
-        .with_base_asset("ATOM")
+        .with_market_token("ATOM")
         .build();
 
     assert_eq!(
@@ -43,7 +43,7 @@ fn deposit_wrong_denom_fails() {
     let lender = "lender";
     let mut suite = SuiteBuilder::new()
         .with_funds(lender, &[coin(50, "BTC")])
-        .with_base_asset("ATOM")
+        .with_market_token("ATOM")
         .build();
 
     assert_eq!(
@@ -58,7 +58,7 @@ fn deposit_wrong_denom_fails() {
 #[test]
 fn deposit_nothing_fails() {
     let lender = "lender";
-    let mut suite = SuiteBuilder::new().with_base_asset("ATOM").build();
+    let mut suite = SuiteBuilder::new().with_market_token("ATOM").build();
 
     assert_eq!(
         suite.deposit(lender, &[]).unwrap_err().to_string(),
@@ -69,10 +69,10 @@ fn deposit_nothing_fails() {
 #[test]
 fn query_transferable_amount() {
     let lender = "lender";
-    let base_asset = "base";
+    let market_token = "base";
     let mut suite = SuiteBuilder::new()
-        .with_base_asset(base_asset)
-        .with_funds(lender, &[coin(100, base_asset)])
+        .with_market_token(market_token)
+        .with_funds(lender, &[coin(100, market_token)])
         .build();
 
     let btoken = suite.btoken();
@@ -86,7 +86,7 @@ fn query_transferable_amount() {
     assert_eq!(Uint128::zero(), resp);
 
     // Deposit base asset and mint some L tokens, then query again
-    suite.deposit(lender, &[coin(100, base_asset)]).unwrap();
+    suite.deposit(lender, &[coin(100, market_token)]).unwrap();
     let resp = suite.query_transferable_amount(ltoken, lender).unwrap();
     assert_eq!(Uint128::new(100), resp);
 

--- a/contracts/lendex-market/src/multitest/instantiate.rs
+++ b/contracts/lendex-market/src/multitest/instantiate.rs
@@ -17,7 +17,7 @@ fn market_instantiate_and_query_config() {
             symbol: "LDX".to_owned(),
             decimals: 9,
             token_id: 1,
-            base_asset: "native_denom".to_owned(),
+            market_token: "native_denom".to_owned(),
             rates: Interest::Linear {
                 base: Decimal::percent(3),
                 slope: Decimal::percent(20)

--- a/contracts/lendex-market/src/multitest/interest.rs
+++ b/contracts/lendex-market/src/multitest/interest.rs
@@ -10,10 +10,10 @@ use crate::state::SECONDS_IN_YEAR;
 fn query_interest() {
     let lender = "lender";
     let borrower = "borrower";
-    let base_asset = "atom";
+    let market_token = "atom";
     let mut suite = SuiteBuilder::new()
-        .with_funds(lender, &[coin(150, base_asset)])
-        .with_base_asset(base_asset)
+        .with_funds(lender, &[coin(150, market_token)])
+        .with_market_token(market_token)
         .build();
 
     // At first, the lender has no l-token, and the contract has no base asset.
@@ -33,7 +33,7 @@ fn query_interest() {
 
     // Deposit some tokens
     suite
-        .deposit(lender, &[Coin::new(100, base_asset)])
+        .deposit(lender, &[Coin::new(100, market_token)])
         .unwrap();
 
     // After the deposit, the lender has 100 l-token and the contract has 100 base asset.
@@ -67,7 +67,7 @@ fn query_interest() {
     );
 
     // Repay some tokens
-    suite.repay(borrower, Coin::new(5, base_asset)).unwrap();
+    suite.repay(borrower, Coin::new(5, market_token)).unwrap();
 
     // Utilisation is now 5% ((10-5)/100).
     // The interest changed according to the linear formula: 3% + 20% * 5% = 3% + 1% = 4%.
@@ -82,7 +82,9 @@ fn query_interest() {
     );
 
     // Lend some more
-    suite.deposit(lender, &[Coin::new(50, base_asset)]).unwrap();
+    suite
+        .deposit(lender, &[Coin::new(50, market_token)])
+        .unwrap();
 
     // Utilisation is now ~3.33% ((10-5)/(100+50)).
     // The interest changed according to the linear formula: 3% + 20% * 3.33% = 3% + 0.67% = 3.67%.
@@ -101,17 +103,17 @@ fn query_interest() {
 fn charge_interest_borrow() {
     let lender = "lender";
     let borrower = "borrower";
-    let base_asset = "atom";
+    let market_token = "atom";
     let mut suite = SuiteBuilder::new()
-        .with_funds(lender, &[coin(2000, base_asset)])
-        .with_funds(borrower, &[coin(500, base_asset)])
+        .with_funds(lender, &[coin(2000, market_token)])
+        .with_funds(borrower, &[coin(500, market_token)])
         .with_interest(4, 20)
-        .with_base_asset(base_asset)
+        .with_market_token(market_token)
         .build();
 
     // Deposit some tokens
     suite
-        .deposit(lender, &[Coin::new(2000, base_asset)])
+        .deposit(lender, &[Coin::new(2000, market_token)])
         .unwrap();
 
     // Borrow some tokens
@@ -133,7 +135,7 @@ fn charge_interest_borrow() {
     // interest is 20%
     // that means btoken 1600 + 320
     // repay 800 -> 1120 left btokens
-    suite.repay(borrower, coin(800, base_asset)).unwrap();
+    suite.repay(borrower, coin(800, market_token)).unwrap();
 
     assert_eq!(
         suite.query_btoken_info().unwrap().total_supply,
@@ -145,7 +147,7 @@ fn charge_interest_borrow() {
     // Utilisation is 48.3%
     // interest is 13.66%
     // btoken 1120 + 13.66% - 800 = 472.992
-    suite.repay(borrower, coin(800, base_asset)).unwrap();
+    suite.repay(borrower, coin(800, market_token)).unwrap();
 
     // TODO: rounding error
     assert_eq!(
@@ -154,7 +156,7 @@ fn charge_interest_borrow() {
     );
 
     // Repay the rest of debt (borrower had extra 500 tokens)
-    suite.repay(borrower, coin(474, base_asset)).unwrap();
+    suite.repay(borrower, coin(474, market_token)).unwrap();
     // TODO: rounding error
     assert_eq!(
         suite.query_btoken_info().unwrap().total_supply,
@@ -166,17 +168,17 @@ fn charge_interest_borrow() {
 fn charge_interest_deposit() {
     let lender = "lender";
     let borrower = "borrower";
-    let base_asset = "atom";
+    let market_token = "atom";
     let mut suite = SuiteBuilder::new()
-        .with_funds(lender, &[coin(4000, base_asset)])
-        .with_funds(borrower, &[coin(2300, base_asset)])
+        .with_funds(lender, &[coin(4000, market_token)])
+        .with_funds(borrower, &[coin(2300, market_token)])
         .with_interest(4, 20)
-        .with_base_asset(base_asset)
+        .with_market_token(market_token)
         .build();
 
     // Deposit some tokens
     suite
-        .deposit(lender, &[Coin::new(2000, base_asset)])
+        .deposit(lender, &[Coin::new(2000, market_token)])
         .unwrap();
 
     // Borrow some tokens
@@ -189,7 +191,7 @@ fn charge_interest_deposit() {
     // that means ltoken 2000 + 1600*20% = 2320
     // deposit 1000 -> 3320 left btokens
     suite
-        .deposit(lender, &[Coin::new(1000, base_asset)])
+        .deposit(lender, &[Coin::new(1000, market_token)])
         .unwrap();
 
     // TODO: rounding error
@@ -208,7 +210,7 @@ fn charge_interest_deposit() {
     // ltokens should go up to 3616.94
     // 3616.94 + 1000 = 4616.94 ltokens
     suite
-        .deposit(lender, &[Coin::new(1000, base_asset)])
+        .deposit(lender, &[Coin::new(1000, market_token)])
         .unwrap();
 
     // TODO: rounding error
@@ -218,7 +220,7 @@ fn charge_interest_deposit() {
     );
 
     // Borrower pays all of his debt
-    suite.repay(borrower, coin(2219, base_asset)).unwrap();
+    suite.repay(borrower, coin(2219, market_token)).unwrap();
     assert_eq!(
         suite.query_btoken_info().unwrap().total_supply,
         // TODO: rounding error

--- a/contracts/lendex-market/src/multitest/suite.rs
+++ b/contracts/lendex-market/src/multitest/suite.rs
@@ -41,7 +41,7 @@ pub struct SuiteBuilder {
     /// Lendex token precision
     decimals: u8,
     /// Native denom for the base asset
-    base_asset: String,
+    market_token: String,
     /// Initial funds to provide for testing
     funds: Vec<(Addr, Vec<Coin>)>,
     /// Initial funds stored on contract
@@ -60,7 +60,7 @@ impl SuiteBuilder {
             name: "lendex".to_owned(),
             symbol: "LDX".to_owned(),
             decimals: 9,
-            base_asset: "native_denom".to_owned(),
+            market_token: "native_denom".to_owned(),
             funds: vec![],
             contract_funds: None,
             interest_base: Decimal::percent(3),
@@ -69,8 +69,8 @@ impl SuiteBuilder {
         }
     }
 
-    pub fn with_base_asset(mut self, denom: impl Into<String>) -> Self {
-        self.base_asset = denom.into();
+    pub fn with_market_token(mut self, denom: impl Into<String>) -> Self {
+        self.market_token = denom.into();
         self
     }
 
@@ -98,7 +98,7 @@ impl SuiteBuilder {
         let mut app = App::default();
         let owner = Addr::unchecked("owner");
 
-        let base_asset = self.base_asset;
+        let market_token = self.market_token;
 
         let token_id = app.store_code(contract_token());
         let contract_id = app.store_code(contract_market());
@@ -111,7 +111,7 @@ impl SuiteBuilder {
                     symbol: self.symbol,
                     decimals: self.decimals,
                     token_id,
-                    base_asset: base_asset.clone(),
+                    market_token: market_token.clone(),
                     interest_rate: Interest::Linear {
                         base: self.interest_base,
                         slope: self.interest_slope,
@@ -154,7 +154,7 @@ impl SuiteBuilder {
             contract,
             ltoken_contract: config.ltoken_contract,
             btoken_contract: config.btoken_contract,
-            base_asset,
+            market_token,
         }
     }
 }
@@ -170,7 +170,7 @@ pub struct Suite {
     /// Address of BToken contract
     btoken_contract: Addr,
     /// The base asset deposited and lended by the contract
-    base_asset: String,
+    market_token: String,
 }
 
 impl Suite {
@@ -244,7 +244,7 @@ impl Suite {
         let amount = self
             .app
             .wrap()
-            .query_balance(owner, &self.base_asset)?
+            .query_balance(owner, &self.market_token)?
             .amount;
         Ok(amount.into())
     }

--- a/contracts/lendex-market/src/multitest/withdraw.rs
+++ b/contracts/lendex-market/src/multitest/withdraw.rs
@@ -7,7 +7,7 @@ fn withdraw_works() {
     let lender = "lender";
     let mut suite = SuiteBuilder::new()
         .with_funds(lender, &[coin(100, "ATOM")])
-        .with_base_asset("ATOM")
+        .with_market_token("ATOM")
         .build();
 
     // Deposit some tokens so we have something to withdraw.
@@ -27,7 +27,7 @@ fn withdraw_overflow_is_handled() {
     let lender = "lender";
     let mut suite = SuiteBuilder::new()
         .with_funds(lender, &[coin(100, "ATOM")])
-        .with_base_asset("ATOM")
+        .with_market_token("ATOM")
         .build();
 
     // Deposit some tokens so we have something to withdraw.

--- a/contracts/lendex-market/src/state.rs
+++ b/contracts/lendex-market/src/state.rs
@@ -16,7 +16,7 @@ pub struct Config {
     pub symbol: String,
     pub decimals: u8,
     pub token_id: u64,
-    pub base_asset: String,
+    pub market_token: String,
     /// Interest rate calculation
     pub rates: Interest,
     pub interest_charge_period: u64,


### PR DESCRIPTION
```bash
sed -i "s/base_asset/market_token/g" $(find . -name "*.rs")
```

I think that name better represents what this asset actually is.
Plus it matches better with added later `common_token` passed down from Credit Agency.