### PR TITLE
isotonic-market: APY query

### DIFF
--- a/contracts/isotonic-market/src/msg.rs
+++ b/contracts/isotonic-market/src/msg.rs
@@ -94,6 +94,8 @@ pub enum QueryMsg {
     CreditLine { account: String },
     /// Returns ReserveResponse
     Reserve {},
+    /// APY Query
+    Apy {},
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -152,4 +154,13 @@ pub enum CreditAgencyExecuteMsg {
     /// Ensures a given account has entered a market. Meant to be called by a specific
     /// market contract - so the sender of the msg would be the market
     EnterMarket { account: String },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ApyResponse {
+    /// How much % interest will a borrower have to pay
+    pub borrower: Decimal,
+    /// How much % interest will a lender earn
+    pub lender: Decimal,
 }

--- a/contracts/isotonic-market/src/multitest.rs
+++ b/contracts/isotonic-market/src/multitest.rs
@@ -1,3 +1,4 @@
+mod apy;
 mod borrow_repay;
 mod ca_mock;
 mod common;

--- a/contracts/isotonic-market/src/multitest/apy.rs
+++ b/contracts/isotonic-market/src/multitest/apy.rs
@@ -1,0 +1,145 @@
+use cosmwasm_std::{coin, Decimal};
+
+use super::suite::SuiteBuilder;
+
+#[test]
+fn nothing_on_market() {
+    let market_token = "atom";
+
+    let mut suite = SuiteBuilder::new().with_market_token(market_token).build();
+
+    // Set arbitrary market/common exchange ratio and credit line (not part of this test)
+    suite.set_token_ratio_one().unwrap();
+
+    // sell/buy ratio between common_token and market_token is 2.0
+    // which means borrowing (buying) 1000 market btokens will get
+    // debt of 2000 common tokens
+    suite
+        .oracle_set_price_market_per_common(Decimal::percent(200))
+        .unwrap();
+
+    let apy = suite.query_apy().unwrap();
+    assert_eq!(apy.borrower, "0.030454529545061873".parse().unwrap());
+    assert_eq!(apy.lender, Decimal::zero());
+}
+
+#[test]
+fn nothing_borrowed() {
+    let lender = "lender";
+    let market_token = "atom";
+
+    let mut suite = SuiteBuilder::new()
+        .with_funds(lender, &[coin(1000, market_token)])
+        .with_market_token(market_token)
+        .build();
+
+    suite.deposit(lender, &[coin(1000, market_token)]).unwrap();
+
+    // Set arbitrary market/common exchange ratio and credit line (not part of this test)
+    suite.set_token_ratio_one().unwrap();
+
+    // sell/buy ratio between common_token and market_token is 2.0
+    // which means borrowing (buying) 1000 market btokens will get
+    // debt of 2000 common tokens
+    suite
+        .oracle_set_price_market_per_common(Decimal::percent(200))
+        .unwrap();
+
+    let apy = suite.query_apy().unwrap();
+    assert_eq!(apy.borrower, "0.030454529545061873".parse().unwrap());
+    assert_eq!(apy.lender, Decimal::zero());
+}
+
+#[test]
+fn half_borrowed() {
+    let borrower = "borrower";
+    let lender = "lender";
+    let market_token = "atom";
+
+    let mut suite = SuiteBuilder::new()
+        .with_funds(lender, &[coin(1000, market_token)])
+        .with_market_token(market_token)
+        .build();
+
+    // Set arbitrary market/common exchange ratio and credit line (not part of this test)
+    suite.set_token_ratio_one().unwrap();
+
+    suite.set_high_credit_line(borrower).unwrap();
+
+    // sell/buy ratio between common_token and market_token is 2.0
+    // which means borrowing (buying) 1000 market btokens will get
+    // debt of 2000 common tokens
+    suite
+        .oracle_set_price_market_per_common(Decimal::percent(200))
+        .unwrap();
+
+    suite.deposit(lender, &[coin(1000, market_token)]).unwrap();
+    suite.borrow(borrower, 500).unwrap();
+
+    let apy = suite.query_apy().unwrap();
+    assert_eq!(apy.borrower, "0.13882829184066357".parse().unwrap());
+    assert_eq!(apy.lender, "0.069414145920331785".parse().unwrap());
+}
+
+#[test]
+fn whole_borrowed() {
+    let borrower = "borrower";
+    let lender = "lender";
+    let market_token = "atom";
+
+    let mut suite = SuiteBuilder::new()
+        .with_funds(lender, &[coin(1000, market_token)])
+        .with_market_token(market_token)
+        .build();
+
+    // Set arbitrary market/common exchange ratio and credit line (not part of this test)
+    suite.set_token_ratio_one().unwrap();
+
+    suite.set_high_credit_line(borrower).unwrap();
+
+    // sell/buy ratio between common_token and market_token is 2.0
+    // which means borrowing (buying) 1000 market btokens will get
+    // debt of 2000 common tokens
+    suite
+        .oracle_set_price_market_per_common(Decimal::percent(200))
+        .unwrap();
+
+    suite.deposit(lender, &[coin(1000, market_token)]).unwrap();
+    suite.borrow(borrower, 1000).unwrap();
+
+    let apy = suite.query_apy().unwrap();
+    assert_eq!(apy.borrower, "0.258599693452152831".parse().unwrap());
+    assert_eq!(apy.lender, "0.258599693452152831".parse().unwrap());
+}
+
+#[test]
+fn with_reserve_factor() {
+    let borrower = "borrower";
+    let lender = "lender";
+    let market_token = "atom";
+
+    let mut suite = SuiteBuilder::new()
+        .with_funds(lender, &[coin(1000, market_token)])
+        .with_market_token(market_token)
+        .with_reserve_factor(20)
+        .build();
+
+    // Set arbitrary market/common exchange ratio and credit line (not part of this test)
+    suite.set_token_ratio_one().unwrap();
+
+    suite.set_high_credit_line(borrower).unwrap();
+
+    // sell/buy ratio between common_token and market_token is 2.0
+    // which means borrowing (buying) 1000 market btokens will get
+    // debt of 2000 common tokens
+    suite
+        .oracle_set_price_market_per_common(Decimal::percent(200))
+        .unwrap();
+
+    suite.deposit(lender, &[coin(1000, market_token)]).unwrap();
+    suite.borrow(borrower, 500).unwrap();
+
+    let apy = suite.query_apy().unwrap();
+    assert_eq!(apy.borrower, "0.13882829184066357".parse().unwrap());
+    assert_eq!(apy.lender, "0.055531316736265428".parse().unwrap());
+}

--- a/contracts/isotonic-market/src/multitest/suite.rs
+++ b/contracts/isotonic-market/src/multitest/suite.rs
@@ -13,8 +13,8 @@ use super::ca_mock::{
     InstantiateMsg as CAInstantiateMsg,
 };
 use crate::msg::{
-    ExecuteMsg, InstantiateMsg, InterestResponse, MigrateMsg, QueryMsg, ReserveResponse, SudoMsg,
-    TokensBalanceResponse, TransferableAmountResponse,
+    ApyResponse, ExecuteMsg, InstantiateMsg, InterestResponse, MigrateMsg, QueryMsg,
+    ReserveResponse, SudoMsg, TokensBalanceResponse, TransferableAmountResponse,
 };
 use crate::state::Config;
 
@@ -462,6 +462,14 @@ impl Suite {
         self.app
             .wrap()
             .query_wasm_smart(ltoken, &isotonic_token::msg::QueryMsg::TokenInfo {})
+            .map_err(|err| anyhow!(err))
+    }
+
+    /// Queries for APY
+    pub fn query_apy(&self) -> AnyResult<ApyResponse> {
+        self.app
+            .wrap()
+            .query_wasm_smart(self.contract.clone(), &QueryMsg::Apy {})
             .map_err(|err| anyhow!(err))
     }
 


### PR DESCRIPTION
Closes #117 

Simple change, more time was spend on understanding underlying math (in particular: rate calculation).

I really took a shoot to commonize it with `calculate_intrest`, but actually the only line which is not just call to some utility function and is reasonably complex slightly differs, and handling it would be probably strange. Also commonizing it would probably hide intermediate utilisation calculation, so it would be redone for the later lender apy calculation, which is not complicated but kind of waste.

At the end I didn't add the period to be calculated, mostly because the actual default period is not 356 days, but some not even number of seconds (which makes sense to avoid handling any odd years or so), and I don't like that default case cannot be expressed by some fixed value, so I decided to drop it (it is actually easy to add, but I feel like not exactly proper for this). If it would be needed it is possible to add query like "simulate_yield" with more configuration options.

It is ready for the review now, I am double checking math on tests (and will check it probably again at morning - more to better understand it than to verify).