### PR TITLE
Update osmo-bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,8 +507,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "osmo-bindings"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167668a15e05084ae48e9568a99fa875f90b8e9f4f7059fae35ad8a7b9678766"
+source = "git+https://github.com/confio/osmosis-bindings?rev=9d67da34195e8f4153e6bb36c2f623317f5f7f3a#9d67da34195e8f4153e6bb36c2f623317f5f7f3a"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -518,13 +517,13 @@ dependencies = [
 [[package]]
 name = "osmo-bindings-test"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ecc7ccbf92b3fa67c7e0fbca431a19d388fe69cb88045717e352a81ddcbef12"
+source = "git+https://github.com/confio/osmosis-bindings?rev=9d67da34195e8f4153e6bb36c2f623317f5f7f3a#9d67da34195e8f4153e6bb36c2f623317f5f7f3a"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus",
+ "itertools",
  "osmo-bindings",
  "schemars",
  "serde",

--- a/contracts/isotonic-credit-agency/Cargo.toml
+++ b/contracts/isotonic-credit-agency/Cargo.toml
@@ -22,7 +22,8 @@ cw2 = "0.13.0"
 isotonic-market = { path = "../isotonic-market", version = "0.5.0", features = ["library"] }
 isotonic-osmosis-oracle = { path = "../isotonic-osmosis-oracle", version = "0.5.0", features = ["library"] }
 isotonic-token = { path = "../isotonic-token", version = "0.5.0", features = ["library"] }
-osmo-bindings = "0.5.0"
+osmo-bindings = { git = "https://github.com/confio/osmosis-bindings", rev = "9d67da34195e8f4153e6bb36c2f623317f5f7f3a" }
+#osmo-bindings = "0.5.0"
 schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.26" }
@@ -33,5 +34,5 @@ either = "1.6"
 anyhow = "1"
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = "0.13.0"
-osmo-bindings-test = "0.5.0"
-
+osmo-bindings-test = { git = "https://github.com/confio/osmosis-bindings", rev = "9d67da34195e8f4153e6bb36c2f623317f5f7f3a" }
+#osmo-bindings-test = "0.5.0"

--- a/contracts/isotonic-market/Cargo.toml
+++ b/contracts/isotonic-market/Cargo.toml
@@ -22,7 +22,8 @@ cw2 = "0.13.0"
 cw20 = "0.13.0"
 isotonic-osmosis-oracle = { path = "../isotonic-osmosis-oracle", version = "0.5.0", features = ["library"] }
 isotonic-token = { path = "../isotonic-token", version = "0.5.0", features = ["library"] }
-osmo-bindings = "0.5.0"
+osmo-bindings = { git = "https://github.com/confio/osmosis-bindings", rev = "9d67da34195e8f4153e6bb36c2f623317f5f7f3a" }
+# osmo-bindings = "0.5.0"
 schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.26" }
@@ -32,4 +33,5 @@ utils = { version = "0.5.0", path = "../../packages/utils" }
 anyhow = "1"
 cosmwasm-schema = { version = "1.0.0-beta6" }
 cw-multi-test = "0.13.0"
-osmo-bindings-test = "0.5.0"
+osmo-bindings-test = { git = "https://github.com/confio/osmosis-bindings", rev = "9d67da34195e8f4153e6bb36c2f623317f5f7f3a" }
+# osmo-bindings-test = "0.5.0"

--- a/contracts/isotonic-osmosis-oracle/Cargo.toml
+++ b/contracts/isotonic-osmosis-oracle/Cargo.toml
@@ -18,7 +18,8 @@ cosmwasm-std = "1.0.0-beta6"
 cosmwasm-storage = "1.0.0-beta6"
 cw-storage-plus = "0.13.0"
 cw2 = "0.13.0"
-osmo-bindings = "0.5.0"
+osmo-bindings = { git = "https://github.com/confio/osmosis-bindings", rev = "9d67da34195e8f4153e6bb36c2f623317f5f7f3a" }
+# osmo-bindings = "0.5.0"
 schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 thiserror = "1.0.26"
@@ -29,4 +30,5 @@ anyhow = "1"
 cosmwasm-schema = "1.0.0-beta6"
 cw-multi-test = "0.13.0"
 derivative = "2"
-osmo-bindings-test = "0.5.0"
+osmo-bindings-test = { git = "https://github.com/confio/osmosis-bindings", rev = "9d67da34195e8f4153e6bb36c2f623317f5f7f3a" }
+# osmo-bindings-test = "0.5.0"


### PR DESCRIPTION
Closes #127 

This updates `osmo-bindings-test` to a new version that can handle testing swaps with routes.

The reason I'm using a git dependency and didn't try to do a release is... Ethan is on holiday and he's the only owner here: https://crates.io/crates/osmo-bindings

Let's just use this workaround for now.